### PR TITLE
D005

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,23 +1,86 @@
-name: C/C++ CI
+name: C++ CI - TeleTrack Sim (Modular DAG)
 
 on:
   push:
-    branches: [ "master" ]
+    paths:
+      - "teletrack_sim/**"
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    paths:
+      - "teletrack_sim/**"
+    branches: ["master"]
 
 jobs:
-  build:
-
+  gnss:
+    name: Build GNSS Module
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: teletrack_sim
     steps:
-    - uses: actions/checkout@v4
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+      - uses: actions/checkout@v4
+      - run: |
+          g++ -std=c++17 -I modules/gnss/include \
+              modules/gnss/src/gnss_simulator.cpp \
+              -c -o gnss_simulator.o
+
+  engine:
+    name: Build Engine Module
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: teletrack_sim
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          g++ -std=c++17 -I modules/engine/include \
+              modules/engine/src/engine_simulator.cpp \
+              -c -o engine_simulator.o
+
+  logger:
+    name: Build Logger Module
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: teletrack_sim
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          g++ -std=c++17 -I modules/logger/include \
+              modules/logger/src/logger.cpp \
+              -c -o logger.o
+
+  aggregator:
+    name: Build Aggregator Module
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: teletrack_sim
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          g++ -std=c++17 -I modules/aggregator/include \
+              modules/aggregator/src/aggregator.cpp \
+              -c -o aggregator.o
+
+  build-main:
+    name: Build & Run TeleTrack Sim
+    needs: [gnss, engine, logger, aggregator]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: teletrack_sim
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Build Directory
+        run: mkdir -p build
+
+      - name: Configure with CMake
+        run: cmake -B build
+
+      - name: Build the Full App
+        run: cmake --build build
+
+      - name: Run App
+        run: ./build/teletrack_sim


### PR DESCRIPTION
This pull request includes significant changes to the C/C++ CI workflow configuration. The changes focus on modularizing the build process for different components of the TeleTrack Sim project.

Key changes include:

### Workflow Configuration

* Updated the workflow name to "C++ CI - TeleTrack Sim (Modular DAG)" and specified paths for triggering the workflow on changes within the `teletrack_sim` directory.

### Job Definitions

* Split the build process into separate jobs for each module (`gnss`, `engine`, `logger`, and `aggregator`) to improve modularity and parallelism. Each job uses `g++` to compile its respective module.
* Added a final job `build-main` that depends on the completion of the module jobs. This job creates a build directory, configures the project with CMake, builds the full application, and runs it.